### PR TITLE
Noma non blocking on monitor mode

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/noma_security.md
+++ b/docs/my-website/docs/proxy/guardrails/noma_security.md
@@ -135,6 +135,7 @@ guardrails:
       # application_id: "my-app"
       # monitor_mode: false
       # block_failures: true
+      # anonymize_input: false
 ```
 
 ### Required Parameters
@@ -147,6 +148,7 @@ guardrails:
 - **`application_id`**: Your application identifier (defaults to `"litellm"`)
 - **`monitor_mode`**: If `true`, logs violations without blocking (defaults to `false`)
 - **`block_failures`**: If `true`, blocks requests when guardrail API failures occur (defaults to `true`)
+- **`anonymize_input`**: If `true`, replaces sensitive content with anonymized version (defaults to `false`)
 
 ## Environment Variables
 
@@ -158,6 +160,7 @@ export NOMA_API_BASE="https://api.noma.security/"   # Optional
 export NOMA_APPLICATION_ID="my-app"                 # Optional
 export NOMA_MONITOR_MODE="false"                    # Optional
 export NOMA_BLOCK_FAILURES="true"                   # Optional
+export NOMA_ANONYMIZE_INPUT="false"                 # Optional
 ```
 
 ## Advanced Configuration
@@ -188,6 +191,20 @@ guardrails:
       mode: "pre_call"
       api_key: os.environ/NOMA_API_KEY
       block_failures: false  # Allow requests to proceed if guardrail API fails
+```
+
+### Content Anonymization
+
+Enable anonymization to replace sensitive content instead of blocking:
+
+```yaml
+guardrails:
+  - guardrail_name: "noma-anonymize"
+    litellm_params:
+      guardrail: noma
+      mode: "pre_call"
+      api_key: os.environ/NOMA_API_KEY
+      anonymize_input: true  # Replace sensitive data with anonymized version
 ```
 
 ### Multiple Guardrails

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
@@ -18,6 +18,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         application_id=litellm_params.application_id,
         monitor_mode=litellm_params.monitor_mode,
         block_failures=litellm_params.block_failures,
+        anonymize_input=litellm_params.anonymize_input,
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,
     )

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -42,6 +42,7 @@ class SupportedGuardrailIntegrations(Enum):
     OPENAI_MODERATION = "openai_moderation"
     NOMA = "noma"
 
+
 class Role(Enum):
     SYSTEM = "system"
     ASSISTANT = "assistant"
@@ -312,7 +313,6 @@ class BedrockGuardrailConfigModel(BaseModel):
     )
 
 
-
 class LakeraV2GuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lakera AI v2 guardrail"""
 
@@ -375,6 +375,10 @@ class NomaGuardrailConfigModel(BaseModel):
         default=None,
         description="If True, blocks requests on API failures. Defaults to True if not provided",
     )
+    anonymize_input: Optional[bool] = Field(
+        default=None,
+        description="If True, replaces sensitive content with anonymized version when only PII/PCI/secrets are detected. Only applies in blocking mode. Defaults to False if not provided",
+    )
 
 
 class BaseLitellmParams(BaseModel):  # works for new and patch update guardrails
@@ -425,7 +429,8 @@ class BaseLitellmParams(BaseModel):  # works for new and patch update guardrails
     )
 
     model: Optional[str] = Field(
-        default=None, description="Optional field if guardrail requires a 'model' parameter"
+        default=None,
+        description="Optional field if guardrail requires a 'model' parameter",
     )
 
     # Model Armor params
@@ -446,7 +451,7 @@ class BaseLitellmParams(BaseModel):  # works for new and patch update guardrails
         default=True,
         description="Whether to fail the request if Model Armor encounters an error",
     )
-    
+
     model_config = ConfigDict(extra="allow", protected_namespaces=())
 
 


### PR DESCRIPTION
## Title

Updated Noma guardrails to non-blocking the mian thread when running in `monitor_mode`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1909" height="870" alt="image" src="https://github.com/user-attachments/assets/6ea3d286-48f9-4aff-a042-0fda31ff3859" />


## Type

🆕 New Feature

## Changes
Calling Noma API in an async task and logging the result when running the guardrail in `monitor_mode`



