### PR TITLE
refactor(opentelemetry): limit metric attributes to prevent memory gr…

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1336,37 +1336,41 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         std_log = kwargs.get("standard_logging_object")
         md = getattr(std_log, "metadata", None) or (std_log or {}).get("metadata", {})
-        for key in [
+        # Only values bounded by configured entities (keys, teams, orgs) belong on a
+        # metric. The SDK stores one aggregation per unique attribute set and never
+        # frees it - opentelemetry-sdk 1.28 implements no cardinality limit - so an
+        # attribute that varies per request (end-user id, caller IP, request headers,
+        # cost) grows the meter provider without bound for the life of the process.
+        # Dropping them at the collector does not help: the aggregations are already
+        # allocated in-process before export.
+        # This list is the complement of the collector's transform/litellm_genai
+        # delete_key set: everything it strips before export is omitted here, and
+        # everything it forwards is kept, so exported series are unchanged.
+        for key in (
             "user_api_key_hash",
             "user_api_key_alias",
             "user_api_key_team_id",
-            "user_api_key_org_id",
-            "user_api_key_user_id",
             "user_api_key_team_alias",
-            "user_api_key_user_email",
-            "spend_logs_metadata",
-            "requester_ip_address",
-            "requester_metadata",
-            "user_api_key_end_user_id",
-            "prompt_management_metadata",
+            "user_api_key_org_id",
             "applied_guardrails",
-            "mcp_tool_call_metadata",
-            "vector_store_request_metadata",
-        ]:
+        ):
             value = md.get(key)
             if value is None:
                 continue
-            if isinstance(value, (dict, list)):
-                common_attrs[f"metadata.{key}"] = safe_dumps(value)
-            else:
-                common_attrs[f"metadata.{key}"] = str(value)
+            common_attrs[f"metadata.{key}"] = (
+                safe_dumps(value) if isinstance(value, (dict, list)) else str(value)
+            )
 
-        # get hidden params
-        hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get(
-            "hidden_params", {}
-        )
-        if hidden_params:
-            common_attrs["hidden_params"] = safe_dumps(hidden_params)
+        # requester_metadata is a dict of the caller's headers, and traceparent is
+        # unique per request, so lift only the two grouping fields off it. These are
+        # deliberately unprefixed: the collector used to derive "component"/"platform"
+        # from the raw dict, and consumers group by those names.
+        requester_metadata = md.get("requester_metadata")
+        if isinstance(requester_metadata, dict):
+            for key in ("component", "platform"):
+                value = requester_metadata.get(key)
+                if value is not None:
+                    common_attrs[key] = str(value)
 
         if self._operation_duration_histogram:
             self._operation_duration_histogram.record(

--- a/tests/logging_callback_tests/test_otel_metrics_cardinality.py
+++ b/tests/logging_callback_tests/test_otel_metrics_cardinality.py
@@ -1,0 +1,136 @@
+"""Metric attributes must not carry per-request values.
+
+opentelemetry-sdk 1.28 keeps one aggregation per unique attribute set for the
+life of the meter provider and implements no cardinality limit, so a single
+request-scoped attribute makes memory grow linearly with traffic forever.
+This asserts the attribute sets stay constant as request count grows.
+"""
+
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+
+
+class _Recorder:
+    """Stands in for a Histogram, remembering every distinct attribute set."""
+
+    def __init__(self):
+        self.attribute_sets = set()
+
+    def record(self, value, attributes=None):
+        self.attribute_sets.add(frozenset((attributes or {}).items()))
+
+
+def _make_logger():
+    # Bypass __init__ so no exporter, provider or network setup is needed.
+    logger = OpenTelemetry.__new__(OpenTelemetry)
+    # _gen_ai_semconv_latest_experimental is a read-only property off this;
+    # the default config opts into no semconv categories.
+    logger.config = OpenTelemetryConfig()
+    recorders = {}
+    for name in (
+        "_operation_duration_histogram",
+        "_token_usage_histogram",
+        "_cost_histogram",
+        "_time_to_first_token_histogram",
+        "_time_per_output_token_histogram",
+        "_response_duration_histogram",
+    ):
+        recorders[name] = _Recorder()
+        setattr(logger, name, recorders[name])
+    return logger, recorders
+
+
+def _make_kwargs():
+    """One request's worth of kwargs, with the request-scoped fields varying."""
+    return {
+        "model": "bedrock/us.meta.llama3-3-70b-instruct-v1:0",
+        "litellm_params": {"custom_llm_provider": "bedrock"},
+        "optional_params": {"stream": False},
+        "response_cost": 0.00123,
+        "standard_logging_object": {
+            "metadata": {
+                # stable, bounded by how many keys/teams exist
+                "user_api_key_hash": "d8be13191ed55305",
+                "user_api_key_alias": "cigna-aidr",
+                "user_api_key_team_alias": "brokers",
+                "user_api_key_team_id": "054aec77-de20-4d9d",
+                "applied_guardrails": ["noma-prompt-injection"],
+                # varies per request - must never reach a metric attribute
+                "user_api_key_end_user_id": str(uuid.uuid4()),
+                "requester_ip_address": f"10.2.{uuid.uuid4().int % 255}.{uuid.uuid4().int % 255}",
+                "requester_metadata": {
+                    "component": "ClassifierName_IndirectPromptInjectionLLMClassifier",
+                    "platform": "PLATFORM_CLAUDE_CODE",
+                    "headers": {"traceparent": f"00-{uuid.uuid4().hex}-01"},
+                },
+                "spend_logs_metadata": {"request_id": str(uuid.uuid4())},
+            },
+            "hidden_params": {
+                "response_cost": uuid.uuid4().int % 10**9 / 10**12,
+                "litellm_overhead_time_ms": uuid.uuid4().int % 1000 / 7.0,
+                "cache_key": uuid.uuid4().hex,
+            },
+        },
+    }
+
+
+def test_metric_attributes_are_bounded():
+    logger, recorders = _make_logger()
+    start = datetime.now()
+    end = start + timedelta(seconds=1)
+    response_obj = {"usage": {"prompt_tokens": 2419, "completion_tokens": 53}}
+
+    counts = []
+    for _ in range(3):
+        for _ in range(200):
+            logger._record_metrics(_make_kwargs(), response_obj, start, end)
+        counts.append(
+            sum(len(r.attribute_sets) for r in recorders.values())
+        )
+
+    assert counts[0] == counts[-1], (
+        f"distinct metric attribute sets grew with request count: {counts}. "
+        "A request-scoped value is leaking into metric attributes."
+    )
+
+    recorded = set()
+    for recorder in recorders.values():
+        for attribute_set in recorder.attribute_sets:
+            recorded.update(key for key, _ in attribute_set)
+
+    for forbidden in (
+        "metadata.user_api_key_end_user_id",
+        "metadata.requester_ip_address",
+        "metadata.requester_metadata",
+        "metadata.spend_logs_metadata",
+        "hidden_params",
+    ):
+        assert forbidden not in recorded, f"{forbidden} must not be a metric attribute"
+
+    # Every attribute the collector's transform/litellm_genai forwards must still
+    # be emitted, under the same name, or downstream dashboards lose a dimension.
+    # component/platform are unprefixed because that is what the collector
+    # previously derived from requester_metadata.
+    for required in (
+        "gen_ai.request.model",
+        "gen_ai.system",
+        "metadata.user_api_key_hash",
+        "metadata.user_api_key_alias",
+        "metadata.user_api_key_team_id",
+        "metadata.user_api_key_team_alias",
+        "metadata.applied_guardrails",
+        "component",
+        "platform",
+    ):
+        assert required in recorded, f"{required} should still be a metric attribute"
+
+
+if __name__ == "__main__":
+    test_metric_attributes_are_bounded()
+    print("OK: metric attribute cardinality is bounded")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which dimensions appear on exported GenAI metrics; dashboards that relied on stripped attributes at the collector should see the same exported series, but any consumer reading raw in-process metrics before the collector could lose dimensions.
> 
> **Overview**
> Fixes **unbounded in-process memory growth** when OTEL metrics are enabled: histograms no longer attach per-request metadata or `hidden_params` to `common_attrs` in `_record_metrics`.
> 
> **Kept on metrics** are bounded dimensions aligned with what the collector’s `litellm_genai` transform still exports (key/team/org aliases, guardrails, plus unprefixed `component` and `platform` lifted from `requester_metadata`). **Dropped** from metrics include end-user id, caller IP, full `requester_metadata`, spend-log metadata, MCP/vector-store metadata, and serialized `hidden_params`—values that created a new aggregation per request in the OpenTelemetry SDK.
> 
> Span attribute behavior in `set_attributes` is unchanged; this targets metric recording only. A new test simulates hundreds of requests with varying forbidden fields and asserts distinct attribute sets stay flat while required dimensions remain present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266cbf446da2bfa8bd55bb63e72de04f0a80494d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->