### PR TITLE
fix(bedrock): never forward toolSpec.strict to Converse

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -711,19 +711,20 @@ def bedrock_converse_supports_strict_tools(model: str) -> bool:
     """
     Whether ``toolSpec.strict`` can be forwarded to Bedrock Converse for ``model``.
 
-    Non-Anthropic Bedrock families (Nova, Llama, GPT-OSS) reject the field
-    outright. Anthropic models forward it unless their entry in
-    ``model_prices_and_context_window.json`` sets
-    ``bedrock_converse_supports_strict_tools: false`` — Bedrock routes those
-    (Opus 4.7/4.8, see #31582) through a stricter validator that rejects the
-    ``strict`` key on ``toolSpec`` even though Anthropic's native API accepts
-    it as a top-level tool field.
+    Noma fork: never. Upstream forwards ``strict`` — and the ``additionalProperties``
+    Bedrock requires alongside it — for every Anthropic model whose entry in
+    ``model_prices_and_context_window.json`` omits
+    ``bedrock_converse_supports_strict_tools: false``. That default is unsafe for us:
+    Bedrock rejects the key for models the shipped cost map does not list yet (Claude
+    Sonnet 5 is in our model_list and its fix, #35688, missed v1.96.0), and the cost
+    map is fetched from GitHub at runtime, so upstream can change our wire payload
+    without a version bump.
+
+    Returning ``False`` pins the v1.89.5 payload, which never carried ``strict``.
+    Drop this return to restore upstream behaviour once we ship a release containing
+    #35688; ``_get_bedrock_converse_strict_tools_flag`` stays wired for that.
     """
-    base = get_bedrock_base_model(model)
-    if not base.startswith("anthropic"):
-        return False
-    flag = _get_bedrock_converse_strict_tools_flag(base)
-    return flag if flag is not None else True
+    return False
 
 
 def _get_bedrock_converse_strict_tools_flag(base_model: str) -> bool | None:

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -4,6 +4,11 @@ Bedrock Converse routes Claude Opus 4.7/4.8 and Claude Sonnet 4 through an
 Anthropic-compatible validator that rejects ``toolSpec.strict`` even though
 Anthropic's native API accepts ``strict`` as a top-level tool field. See
 BerriAI/litellm#31582.
+
+This fork opts out of forwarding ``strict`` for every model, so the assertions
+below expect it dropped everywhere rather than only for the models upstream
+flags in ``model_prices_and_context_window.json``. See
+``bedrock_converse_supports_strict_tools``.
 """
 
 import pytest
@@ -73,12 +78,18 @@ def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
         "bedrock/us.anthropic.claude-opus-4-5",
     ],
 )
-def test_bedrock_tools_pt_strict_kept_for_other_anthropic(model_id: str) -> None:
-    """Sonnet 4.5/4.6 and Opus <=4.6 accept toolSpec.strict — keep forwarding it."""
+def test_bedrock_tools_pt_strict_dropped_for_upstream_supported_anthropic(
+    model_id: str,
+) -> None:
+    """Upstream forwards strict for these; the fork opt-out drops it everywhere."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
+    tool_spec = result[0]["toolSpec"]
     assert (
-        result[0]["toolSpec"]["strict"] is True
-    ), f"strict missing for {model_id}: {result[0]['toolSpec']}"
+        "strict" not in tool_spec
+    ), f"strict leaked into toolSpec for {model_id}: {tool_spec}"
+    assert (
+        "additionalProperties" not in tool_spec["inputSchema"]["json"]
+    ), f"additionalProperties leaked into toolSpec for {model_id}: {tool_spec}"
 
 
 @pytest.mark.parametrize(
@@ -108,11 +119,11 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         bedrock_converse_supports_strict_tools(
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
         )
-        is True
+        is False
     )
     assert (
         bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-opus-4-6")
-        is True
+        is False
     )
     assert bedrock_converse_supports_strict_tools("us.amazon.nova-micro-v1:0") is False
     assert bedrock_converse_supports_strict_tools("") is False

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -976,10 +976,9 @@ def test_bedrock_tools_unpack_defs():
 def test_bedrock_tools_pt_strict_parameter():
     """Regression for strict tools on the Bedrock Converse path.
 
-    Claude on Bedrock honours strict in toolSpec (with additionalProperties, which
-    Bedrock requires alongside strict); without forwarding it the model ignores the
-    enum constraint the caller asked for. Every other Bedrock family (Nova, Llama,
-    GPT-OSS) rejects the strict field, so it must only be forwarded for Claude.
+    This fork never forwards strict (nor the additionalProperties Bedrock requires
+    alongside it) to Converse, for any family — see
+    bedrock_converse_supports_strict_tools.
     """
     tools_with_strict = [
         {
@@ -1000,8 +999,8 @@ def test_bedrock_tools_pt_strict_parameter():
     result = _bedrock_tools_pt(
         tools_with_strict, model="anthropic.claude-sonnet-4-5-20250929-v1:0"
     )
-    assert result[0]["toolSpec"]["strict"] is True
-    assert result[0]["toolSpec"]["inputSchema"]["json"]["additionalProperties"] is False
+    assert "strict" not in result[0]["toolSpec"]
+    assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
 
     result = _bedrock_tools_pt(tools_with_strict, model="us.amazon.nova-micro-v1:0")
     assert "strict" not in result[0]["toolSpec"]


### PR DESCRIPTION
## Summary

Pins the Bedrock Converse tool payload to what `v1.89.5` sent, so the v1.96.0 upgrade cannot regress Claude tool-calling.

Upstream v1.96.0 forwards `toolSpec.strict` — and the `additionalProperties` Bedrock requires alongside it — for **every** Anthropic model whose entry in `model_prices_and_context_window.json` does not set `bedrock_converse_supports_strict_tools: false`. Two problems with that default here:

- **Sonnet 5 is unfixed in this release.** Bedrock rejects `strict` for models the shipped cost map does not list yet. `claude-sonnet-5` is in our prod `model_list`, and the fix that would handle it (BerriAI/litellm#35688, plus #33196) landed on `main` *after* v1.96.0.
- **The cost map is fetched from GitHub at runtime.** Upstream can therefore change what we put on the wire without a version bump — the same live-config hazard that has bitten us before.

We are exposed even without setting `strict` ourselves: the Responses→ChatCompletions bridge stamps `strict` onto every function tool it translates, and v1.96.0 does not contain the falsy-`strict` drop. `additionalProperties` also forwards on its own when `strict` is absent.

`bedrock_converse_supports_strict_tools()` now returns `False` unconditionally. `_get_bedrock_converse_strict_tools_flag` is deliberately left wired so restoring upstream behaviour is a one-line revert once we pick up a release containing #35688.

## Verification

- `bedrock_converse_supports_strict_tools()` has exactly one functional consumer (`factory.py:5058`); the other references are the `ModelInfo` field declaration and its plumbing.
- That flag guards exactly two statements in `BedrockToolSpec.__init__` — adding `additionalProperties` and adding `strict`. With it off, the toolSpec is `{inputSchema:{json:{type,properties,required}}, name, description}`, key-for-key what v1.89.5 built.
- No bypass: nothing else under `litellm/llms/bedrock/` references `strict`, and the two other `toolSpec` builders (`count_tokens`, `realtime`) never carried it.
- Ran the real v1.96.0 `BedrockToolSpec` against the v1.89.5 construction over 15 combinations (`strict` true/false/absent × schemas with/without `additionalProperties` and junk keys): **0 mismatches**.
- 0 models set the flag to `true` in either the bundled backup (23 `false`) or the live remote map (29 `false`), so the opt-out applies uniformly today.

## Test plan

- [x] `pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py <factory strict test> tests/test_litellm/test_claude_opus_5_config.py` — 52 passed
- [x] Full Bedrock + prompt-template unit suites diffed against a pristine-branch baseline — failure set **byte-identical** (128 pre-existing failures, all from `botocore` missing in the locked env)
- [x] `ruff check` and `ruff format --check` clean on the changed module

## Note

Not a fix for a bug we have today — v1.89.5 never sent `strict` — this keeps it that way through the upgrade. If we ever want strict tools on Bedrock Claude, the answer is a release containing #35688, not this patch.

Made with [Cursor](https://cursor.com)