### PR TITLE
perf(guardrails): stop forwarding the conversation twice in the noma v2 payload

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -160,8 +160,10 @@ class NomaV2Guardrail(CustomGuardrail):
         return payload
 
     @staticmethod
-    def _without_duplicated_conversation(data: Mapping[str, Any]) -> dict[str, Any]:  # mutable-ok: handed to _sanitize_payload_for_transport, which takes a dict
-        return {  # mutable-ok: same - the trimmed copy is the sanitizer's input
+    def _without_duplicated_conversation(
+        data: Mapping[str, Any],
+    ) -> dict[str, Any]:  # mutable-ok: fed to _sanitize_payload_for_transport, which takes a dict
+        return {  # mutable-ok: same - the sanitizer needs a real dict
             key: value for key, value in data.items() if key not in _DUPLICATED_CONVERSATION_KEYS
         }
 

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -7,6 +7,7 @@
 import enum
 import json
 import os
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
 from urllib.parse import urlparse
@@ -141,10 +142,12 @@ class NomaV2Guardrail(CustomGuardrail):
             self._without_duplicated_conversation(request_data)
         )
         if logging_obj is not None:
-            model_call_details = getattr(logging_obj, "model_call_details", None)
-            if isinstance(model_call_details, dict):
-                model_call_details = self._without_duplicated_conversation(model_call_details)
-            payload_request_data["litellm_logging_obj"] = model_call_details
+            model_call_details: Final = getattr(logging_obj, "model_call_details", None)
+            payload_request_data["litellm_logging_obj"] = (
+                self._without_duplicated_conversation(model_call_details)
+                if isinstance(model_call_details, dict)
+                else model_call_details
+            )
 
         payload: Final[dict[str, Any]] = {
             "inputs": inputs,
@@ -157,8 +160,10 @@ class NomaV2Guardrail(CustomGuardrail):
         return payload
 
     @staticmethod
-    def _without_duplicated_conversation(data: dict) -> dict:
-        return {key: value for key, value in data.items() if key not in _DUPLICATED_CONVERSATION_KEYS}
+    def _without_duplicated_conversation(data: Mapping[str, Any]) -> dict[str, Any]:  # mutable-ok: handed to _sanitize_payload_for_transport, which takes a dict
+        return {  # mutable-ok: same - the trimmed copy is the sanitizer's input
+            key: value for key, value in data.items() if key not in _DUPLICATED_CONVERSATION_KEYS
+        }
 
     @staticmethod
     def _sanitize_payload_for_transport(payload: dict) -> dict:

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -36,6 +36,11 @@ _AIDR_SCAN_ENDPOINT: Final = "/litellm/guardrail"
 _INTERVENED_INPUT_FIELDS: Final = ("texts", "images", "tools", "tool_calls")
 _DEFAULT_API_BASE_HOSTNAME: Final = urlparse(_DEFAULT_API_BASE).hostname
 
+# The conversation the scanner reads is carried by `inputs`; these keys repeat it inside
+# `request_data`, so forwarding them uploads the whole conversation - base64 images and all -
+# a second time. Everything else in `request_data` is still passed through untouched.
+_DUPLICATED_CONVERSATION_KEYS: Final = ("messages", "input")
+
 
 class _Action(str, enum.Enum):
     BLOCKED = "BLOCKED"
@@ -131,9 +136,15 @@ class NomaV2Guardrail(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         application_id: str | None,
     ) -> dict:
-        payload_request_data: Final = self._sanitize_payload_for_transport(request_data)
+        # Trimmed before serialization, so the duplicated conversation is never encoded at all.
+        payload_request_data: Final = self._sanitize_payload_for_transport(
+            self._without_duplicated_conversation(request_data)
+        )
         if logging_obj is not None:
-            payload_request_data["litellm_logging_obj"] = getattr(logging_obj, "model_call_details", None)
+            model_call_details = getattr(logging_obj, "model_call_details", None)
+            if isinstance(model_call_details, dict):
+                model_call_details = self._without_duplicated_conversation(model_call_details)
+            payload_request_data["litellm_logging_obj"] = model_call_details
 
         payload: Final[dict[str, Any]] = {
             "inputs": inputs,
@@ -144,6 +155,10 @@ class NomaV2Guardrail(CustomGuardrail):
         if application_id:
             payload["application_id"] = application_id
         return payload
+
+    @staticmethod
+    def _without_duplicated_conversation(data: dict) -> dict:
+        return {key: value for key, value in data.items() if key not in _DUPLICATED_CONVERSATION_KEYS}
 
     @staticmethod
     def _sanitize_payload_for_transport(payload: dict) -> dict:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
@@ -129,13 +129,50 @@ class TestNomaV2Configuration:
         )
 
         assert payload["inputs"] == inputs
-        assert payload["request_data"] == request_data
+        # Everything except the duplicated conversation is forwarded untouched, so a scanner-side
+        # change that starts reading a new request_data key needs no hook release.
+        assert payload["request_data"] == {
+            key: value for key, value in request_data.items() if key != "messages"
+        }
         assert payload["input_type"] == "request"
         assert payload["monitor_mode"] is False
         assert payload["application_id"] == "dynamic-app"
         assert "dynamic_params" not in payload
         assert "x-noma-context" not in payload
         assert "input" not in payload
+
+    def test_build_scan_payload_drops_conversation_duplicated_in_request_data(
+        self, noma_v2_guardrail
+    ):
+        """The scan reads the conversation from `inputs`; repeating it in `request_data` uploaded
+        the whole thing - base64 images included - a second time."""
+        inputs = {"texts": ["hello"]}
+        request_data = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "input": [{"role": "user", "content": "hello"}],
+            "metadata": {"headers": {"x-noma-application-id": "header-app"}},
+            "litellm_call_id": "call-id-1",
+            "stream": True,
+        }
+
+        payload = noma_v2_guardrail._build_scan_payload(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+            logging_obj=None,
+            application_id="dynamic-app",
+        )
+
+        assert "messages" not in payload["request_data"]
+        assert "input" not in payload["request_data"]
+        # Keys the scanner reads for context must survive.
+        assert payload["request_data"]["metadata"] == request_data["metadata"]
+        assert payload["request_data"]["litellm_call_id"] == "call-id-1"
+        assert payload["request_data"]["stream"] is True
+        # The conversation still reaches the scanner through `inputs`.
+        assert payload["inputs"] == inputs
+        # The caller's dict is untouched.
+        assert "messages" in request_data
 
     def test_build_scan_payload_deep_copies_request_data(self, noma_v2_guardrail):
         request_data = {
@@ -153,11 +190,11 @@ class TestNomaV2Configuration:
         payload["request_data"]["metadata"]["headers"][
             "x-noma-application-id"
         ] = "mutated-value"
-        payload["request_data"]["messages"][0]["content"] = "changed-content"
 
         assert (
             request_data["metadata"]["headers"]["x-noma-application-id"] == "header-app"
         )
+        # Trimming the duplicated conversation must not mutate the caller's dict either.
         assert request_data["messages"][0]["content"] == "hello"
 
     def test_build_scan_payload_survives_unpicklable_request_data(
@@ -191,14 +228,13 @@ class TestNomaV2Configuration:
 
         assert isinstance(payload["request_data"], dict)
         assert payload["request_data"]["event_loop"] == "<fake-uvloop-loop>"
-        assert payload["request_data"]["messages"] == [
-            {"role": "user", "content": "hello"}
-        ]
+        assert "messages" not in payload["request_data"]
 
         # Original request_data must not have been mutated by the copy.
         assert request_data["event_loop"] is unpicklable
+        assert request_data["messages"] == [{"role": "user", "content": "hello"}]
 
-    def test_build_scan_payload_passes_model_call_details_as_is(
+    def test_build_scan_payload_passes_model_call_details_without_conversation(
         self, noma_v2_guardrail
     ):
         class _LoggingObj:
@@ -223,9 +259,10 @@ class TestNomaV2Configuration:
             application_id="test-app",
         )
 
+        # model_call_details repeats the conversation a third time; everything else still passes
+        # through, including complete_streaming_response which the scanner reads for stream end.
         assert payload["request_data"]["litellm_logging_obj"] == {
             "model": "gpt-4.1-mini",
-            "messages": [{"role": "user", "content": "hello"}],
             "stream": False,
             "call_type": "acompletion",
             "litellm_call_id": "call-id-123",


### PR DESCRIPTION
## Summary

The Noma v2 guardrail sends the conversation to the scanner in `inputs`. It also forwarded `request_data` whole, which repeats that same conversation under `messages` (or `input` on the responses API), and then attached `logging_obj.model_call_details`, which repeats it a third time.

For image-heavy calls that duplication *is* the request. A production scan measured with per-request size attributes:

| | |
|---|---|
| total body | **100.1 MB** |
| `request_data` | **94.8 MB** |
| `inputs` (what is actually scanned) | 5.1 MB |
| base64 image bytes | 99.2 MB across **234 images** |
| messages in the conversation | **2** |

Fleet-wide over 118,686 scans, p95 `request_data` is 13.7 MB against 1.3 MB of `inputs` — roughly 10x the scanned content, on every request.

This drops the duplicated conversation from `request_data` and from `model_call_details`.

## What is removed, and why only this

`messages` and `input` — nothing else.

Deliberately a **denylist rather than an allowlist**: every other key is forwarded untouched, so a scanner-side change that starts reading a new `request_data` key does not need a matching hook release. An allowlist would be smaller on the wire but would silently starve the scanner the next time it reads something new.

The removed keys are ones the scanner provably never reads. Its context comes only from:

`metadata`, `litellm_metadata`, `provider_specific_header`, `litellm_session_id`, `litellm_trace_id`, `litellm_call_id`, `stream`, `response`/`responses` ids and finish reasons, and `litellm_logging_obj.complete_streaming_response`.

All of those still pass through, including `complete_streaming_response`, which the scanner uses to detect end-of-stream.

The conversation still reaches the scanner in full — via `inputs`, which is unchanged. **No detection coverage is lost.**

## Changes

1. `_DUPLICATED_CONVERSATION_KEYS` plus a `_without_duplicated_conversation` helper.
2. `_build_scan_payload` trims `request_data`, and trims `model_call_details` before attaching it as `litellm_logging_obj`.
3. Trimming happens **before** `_sanitize_payload_for_transport`, so the duplicate is never serialized either — the proxy stops paying to encode it, not just to upload it.

## Tests

Four existing tests asserted the duplication (`payload["request_data"] == request_data`, and one named `..._passes_model_call_details_as_is`). They now assert the trim while keeping what they originally guarded:

- deep-copy semantics — the caller's dict is still never mutated
- the NOM-8044 unpicklable-object regression (`uvloop.Loop` in `request_data`)

Added `test_build_scan_payload_drops_conversation_duplicated_in_request_data`, covering both `messages` and `input`, that context keys survive, and that the caller's dict is untouched.

`5 passed` for the payload tests; `28 passed, 2 failed` for the file. Both failures (`test_provider_specific_params_include_noma_v2_fields`, `test_self_managed_path_without_api_key_omits_authorization_header`) reproduce identically on a clean tree with this change stashed — pre-existing and unrelated.

## Compatibility

`request_data` is a free-form object on the scanner side, so a trimmed map is accepted by every broker version, old and new. No coordinated release is required and the change can be rolled back on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guardrail payload shaping with a narrow denylist; scanning still uses `inputs` and scanner context keys remain forwarded.
> 
> **Overview**
> **Noma v2 scan payloads no longer repeat the full conversation** in `request_data` or `litellm_logging_obj`, cutting proxy CPU and upload size on image-heavy traffic while leaving scanner coverage on `inputs` unchanged.
> 
> `_build_scan_payload` now strips only `messages` and `input` (denylist) from `request_data` and from `logging_obj.model_call_details` via `_without_duplicated_conversation`, **before** `_sanitize_payload_for_transport`, so duplicates are not JSON-encoded. All other `request_data` keys (metadata, trace/call ids, `complete_streaming_response`, etc.) still pass through. Tests were updated and extended to assert trimming, non-mutation of caller dicts, and unchanged NOM-8044 sanitization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ea488ce36c7dfeda3b2e99a25298bd68100955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->